### PR TITLE
fix(use-fetch): trigger refetch when query is invalidated externally

### DIFF
--- a/src/composables/useFetch/index.ts
+++ b/src/composables/useFetch/index.ts
@@ -362,6 +362,15 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
     }
   );
 
+  watch(
+    () => currentEntry.value?.updatedAt,
+    (newUpdatedAt) => {
+      if (newUpdatedAt === 0 && isEnabled.value) {
+        internalFetch();
+      }
+    }
+  );
+
   onScopeDispose(() => {
     const k = lastSubscribedKey;
     if (!k) return;


### PR DESCRIPTION
## Description
Previously, useFetch only watched for changes in `key` or `enabled`.
Calling `queryClient.invalidateQuery()` would reset `updatedAt` to 0,
but the active hook would not react to this change immediately.

This commit adds a watcher for `entry.updatedAt`. When the timestamp
resets to 0, `internalFetch()` is now automatically triggered.

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
