### PR TITLE
feat(query-client): add bulk operations

### DIFF
--- a/src/composables/QueryClient/index.ts
+++ b/src/composables/QueryClient/index.ts
@@ -24,6 +24,25 @@ export class QueryClient {
     this.config = config;
   }
 
+  private isMatch(entryKeyRaw: any, filterKeyRaw: any): boolean {
+    const sEntry = serializeKey(entryKeyRaw);
+    const sFilter = serializeKey(filterKeyRaw);
+
+    if (sEntry === sFilter) {
+      return true;
+    }
+
+    if (Array.isArray(filterKeyRaw) && Array.isArray(entryKeyRaw)) {
+      if (filterKeyRaw.length > entryKeyRaw.length) return false;
+      return filterKeyRaw.every((filterItem, index) => {
+        const entryItem = entryKeyRaw[index];
+        return serializeKey(filterItem) === serializeKey(entryItem);
+      });
+    }
+
+    return false;
+  }
+
   /**
    * Subscribe to cache changes.
    * Useful for DevTools or custom loggers.
@@ -70,13 +89,16 @@ export class QueryClient {
     return this.entries.get(serializeKey(key)) as CacheEntry<T> | undefined;
   }
 
-  setEntry<T>(key: string | readonly any[], data: CacheEntry<T>) {
+  setEntry<T>(
+    key: string | readonly any[],
+    data: Omit<CacheEntry<T>, 'rawKey'>
+  ) {
     const sKey = serializeKey(key);
     const isNew = !this.entries.has(sKey);
 
-    this.entries.set(sKey, data);
+    this.entries.set(sKey, { rawKey: key, ...data });
 
-    this.notify(isNew ? 'added' : 'updated', sKey, data);
+    this.notify(isNew ? 'added' : 'updated', sKey, { rawKey: key, ...data });
   }
 
   removeEntry(key: string | readonly any[]) {
@@ -149,6 +171,25 @@ export class QueryClient {
     });
   }
 
+  updateEntries<T>(
+    filters: string | readonly any[],
+    updated: (old: T | undefined) => T | undefined
+  ) {
+    this.entries.forEach((entry) => {
+      if (this.isMatch(entry.rawKey, filters)) {
+        const prevData = entry.data as T | undefined;
+        const newData = updated(prevData);
+
+        this.setEntry(entry.rawKey, {
+          ...entry,
+          data: newData,
+          status: newData !== undefined ? 'success' : 'pending',
+          updatedAt: Date.now(),
+        });
+      }
+    });
+  }
+
   invalidateQuery(key: string | readonly any[]) {
     const sKey = serializeKey(key);
     const entry = this.entries.get(sKey);
@@ -159,6 +200,16 @@ export class QueryClient {
     this.entries.set(sKey, newEntry);
 
     this.notify('updated', sKey, newEntry);
+  }
+
+  invalidateQueries(key: string | readonly any[]) {
+    this.entries.forEach((entry, sKey) => {
+      if (this.isMatch(entry.rawKey, key)) {
+        const newEntry = { ...entry, updatedAt: 0 };
+        this.entries.set(sKey, newEntry);
+        this.notify('updated', sKey, newEntry);
+      }
+    });
   }
 
   clear() {

--- a/src/composables/QueryClient/queryclient.test.ts
+++ b/src/composables/QueryClient/queryclient.test.ts
@@ -4,10 +4,12 @@ import type { CacheEntry } from '@/types';
 
 // Хелпер для быстрого создания объекта записи
 const createMockEntry = (
-  data: unknown,
+  key: any,
+  data: unknown = 'test-data',
   subscribers = 0,
   cacheTime = 5000
 ): CacheEntry => ({
+  rawKey: key,
   data,
   error: null,
   status: 'success',
@@ -28,7 +30,7 @@ describe('QueryClient', () => {
 
   it('should set and get cache entries', () => {
     const key = 'test-key';
-    const entry = createMockEntry('value');
+    const entry = createMockEntry(key);
     const queryClient = useQueryClient();
 
     queryClient.setEntry(key, entry);
@@ -45,7 +47,7 @@ describe('QueryClient', () => {
   it('should remove an entry manually', () => {
     const key = 'to-delete';
     const queryClient = useQueryClient();
-    queryClient.setEntry(key, createMockEntry('data'));
+    queryClient.setEntry(key, createMockEntry(key));
 
     queryClient.removeEntry(key);
 
@@ -57,7 +59,7 @@ describe('QueryClient', () => {
     const cacheTime = 1000;
     const queryClient = useQueryClient();
 
-    queryClient.setEntry(key, createMockEntry('data', 1, cacheTime));
+    queryClient.setEntry(key, createMockEntry(key, 'data', 1, cacheTime));
 
     queryClient.updateSubscribers(key, 0, cacheTime);
 
@@ -76,7 +78,7 @@ describe('QueryClient', () => {
     const cacheTime = 1000;
 
     const queryClient = useQueryClient();
-    queryClient.setEntry(key, createMockEntry('data', 0, cacheTime));
+    queryClient.setEntry(key, createMockEntry(key, 'data', 0, cacheTime));
     queryClient.updateSubscribers(key, 0, cacheTime);
 
     vi.advanceTimersByTime(900);
@@ -94,7 +96,7 @@ describe('QueryClient', () => {
     const key = 'reset-timer';
     const cacheTime = 1000;
     const queryClient = useQueryClient();
-    queryClient.setEntry(key, createMockEntry('data', 1));
+    queryClient.setEntry(key, createMockEntry(key, 'data', 1));
 
     queryClient.updateSubscribers(key, 0, cacheTime);
     vi.advanceTimersByTime(500);
@@ -115,10 +117,10 @@ describe('QueryClient', () => {
     const key1 = 'k1';
     const key2 = 'k2';
     const queryClient = useQueryClient();
-    queryClient.setEntry(key1, createMockEntry('d1', 0));
+    queryClient.setEntry(key1, createMockEntry(key1, 'd1', 0));
     queryClient.updateSubscribers(key1, 0, 1000);
 
-    queryClient.setEntry(key2, createMockEntry('d2', 1));
+    queryClient.setEntry(key2, createMockEntry(key2, 'd2', 1));
 
     queryClient.clear();
 
@@ -129,10 +131,150 @@ describe('QueryClient', () => {
     vi.runAllTimers();
   });
 
-  it('should handle updateSubscribers for non-existent keys gracefully', () => {
-    const queryClient = useQueryClient();
-    expect(() => {
-      queryClient.updateSubscribers('ghost-key', 1, 1000);
-    }).not.toThrow();
+  describe('Invalidate split (Single vs Multiple)', () => {
+    it('should invalidate an entry by exact string match', () => {
+      const queryClient = useQueryClient();
+      const key = ['secrets', 'list'];
+      const key2 = ['secrets', 'list', 'details']; // Похожий ключ
+      queryClient.setEntry(key, createMockEntry(key));
+      queryClient.setEntry(key2, createMockEntry(key2));
+
+      expect(queryClient.getEntry(key)?.updatedAt).toBeGreaterThan(0);
+
+      queryClient.invalidateQuery(key);
+
+      expect(queryClient.getEntry(key)?.updatedAt).toBe(0);
+      expect(queryClient.getEntry(key2)?.updatedAt).not.toBe(0);
+    });
+
+    it('should invalidate an entry by exact array match', () => {
+      const queryClient = useQueryClient();
+      const key = ['secrets', 'list'];
+      queryClient.setEntry(key, createMockEntry(key));
+
+      queryClient.invalidateQuery(key);
+
+      expect(queryClient.getEntry(key)?.updatedAt).toBe(0);
+    });
+
+    it('should invalidate using prefix matching (Fuzzy Match)', () => {
+      const queryClient = useQueryClient();
+
+      const key1 = ['secrets', 'list', 'all'];
+      const key2 = ['secrets', 'detail', 1];
+      const key3 = ['users', 'list'];
+
+      queryClient.setEntry(key1, createMockEntry(key1));
+      queryClient.setEntry(key2, createMockEntry(key2));
+      queryClient.setEntry(key3, createMockEntry(key3));
+
+      queryClient.invalidateQueries(['secrets']);
+
+      expect(queryClient.getEntry(key1)?.updatedAt).toBe(0);
+      expect(queryClient.getEntry(key2)?.updatedAt).toBe(0);
+      expect(queryClient.getEntry(key3)?.updatedAt).not.toBe(0);
+    });
+
+    it('should invalidate with complex object filters', () => {
+      const queryClient = useQueryClient();
+      const key = ['todos', { status: 'done' }, 'page1'];
+      queryClient.setEntry(key, createMockEntry(key));
+
+      queryClient.invalidateQueries(['todos', { status: 'done' }]);
+
+      expect(queryClient.getEntry(key)?.updatedAt).toBe(0);
+    });
+
+    it('should NOT invalidate if filter is longer than key', () => {
+      const queryClient = useQueryClient();
+      const key = ['secrets'];
+      queryClient.setEntry(key, createMockEntry(key));
+
+      queryClient.invalidateQuery(['secrets', 'list']);
+
+      expect(queryClient.getEntry(key)?.updatedAt).not.toBe(0);
+    });
+
+    it('should NOT invalidate if parts do not match', () => {
+      const queryClient = useQueryClient();
+      const key = ['secrets', 'A'];
+      queryClient.setEntry(key, createMockEntry(key));
+
+      queryClient.invalidateQuery(['secrets', 'B']);
+
+      expect(queryClient.getEntry(key)?.updatedAt).not.toBe(0);
+    });
+
+    it('should handle invalidation of non-existent keys gracefully', () => {
+      const queryClient = useQueryClient();
+      expect(() => {
+        queryClient.invalidateQuery(['random-key']);
+      }).not.toThrow();
+    });
+  });
+
+  describe('Update Split (Entry vs Entries)', () => {
+    it('updateEntry (singular) should update ONLY exact match', () => {
+      const client = useQueryClient();
+      const key1 = ['users', 1];
+      const key2 = ['users', 1, 'details'];
+
+      client.setEntry(key1, createMockEntry(key1, { name: 'Alex' }));
+      client.setEntry(key2, createMockEntry(key2, { description: 'Info' }));
+
+      client.updateEntry(key1, (old: any) => ({ ...old, name: 'Alexander' }));
+
+      expect(client.getEntry(key1)?.data).toEqual({ name: 'Alexander' });
+      expect(client.getEntry(key2)?.data).toEqual({ description: 'Info' });
+    });
+
+    it('updateEntries (plural) should update all fuzzy matches', () => {
+      const client = useQueryClient();
+
+      const keyList = ['posts', 'list'];
+      const keyItem1 = ['posts', 1];
+      const keyItem2 = ['posts', 2];
+      const keyOther = ['comments', 1];
+
+      // Исходные данные - просто объекты для теста
+      client.setEntry(keyList, createMockEntry(keyList, { type: 'list' }));
+      client.setEntry(
+        keyItem1,
+        createMockEntry(keyItem1, { type: 'item', id: 1 })
+      );
+      client.setEntry(
+        keyItem2,
+        createMockEntry(keyItem2, { type: 'item', id: 2 })
+      );
+      client.setEntry(keyOther, createMockEntry(keyOther, { type: 'comment' }));
+
+      client.updateEntries(['posts'], (old: any) => {
+        return { ...old, seen: true };
+      });
+
+      expect(client.getEntry(keyList)?.data).toMatchObject({
+        type: 'list',
+        seen: true,
+      });
+      expect(client.getEntry(keyItem1)?.data).toMatchObject({
+        type: 'item',
+        seen: true,
+      });
+      expect(client.getEntry(keyItem2)?.data).toMatchObject({
+        type: 'item',
+        seen: true,
+      });
+      expect(client.getEntry(keyOther)?.data).not.toHaveProperty('seen');
+    });
+
+    it('updateEntries should handle partial updates safely', () => {
+      const client = useQueryClient();
+      const key = ['data'];
+      client.setEntry(key, createMockEntry(key, 10));
+
+      client.updateEntries(['data'], (old: any) => old + 5);
+
+      expect(client.getEntry(key)?.data).toBe(15);
+    });
   });
 });

--- a/src/composables/useFetch/index.ts
+++ b/src/composables/useFetch/index.ts
@@ -62,10 +62,13 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
 ): UseFetchReturn<TData, TError, TSelected> {
   const queryClient = useQueryClient();
   const rawKey = computed(() => {
-    if (Array.isArray(queryKey)) {
-      return queryKey.map((item) => toValue(item));
+    const val = toValue(queryKey);
+
+    if (Array.isArray(val)) {
+      return val.map((item) => toValue(item));
     }
-    return toValue(queryKey);
+
+    return val;
   });
   const key = computed(() => serializeKey(rawKey.value));
   let lastSubscribedKey: string | null = null;
@@ -141,19 +144,17 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
     return now.value - entry.updatedAt >= staleTime;
   });
 
-  const updateEntry = (
-    partial: Partial<typeof currentEntry.value>,
-    newKey?: string
-  ) => {
-    const targetKey = newKey ?? key.value;
-    const entry = queryClient.entries.get(targetKey);
+  const updateEntry = (partial: Partial<typeof currentEntry.value>) => {
+    const entry = queryClient.entries.get(key.value);
     if (entry) {
-      queryClient.setEntry(key.value, { ...entry, ...partial });
+      queryClient.setEntry(rawKey.value, { ...entry, ...partial });
     }
   };
 
   async function internalFetch(force = false) {
     const fetchKey = key.value;
+    const fetchRawKey = rawKey.value;
+
     if (!isEnabled.value && !force) return;
 
     const existingPromise = queryClient.getPromise(fetchKey);
@@ -168,7 +169,7 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
     const controller = queryClient.getOrCreateController(fetchKey);
 
     if (!entry) {
-      queryClient.setEntry(fetchKey, {
+      queryClient.setEntry(fetchRawKey, {
         data: undefined,
         error: null,
         status: 'pending',
@@ -178,26 +179,23 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
         subscribers: 1,
       });
     } else {
-      updateEntry(
-        {
-          fetchStatus: 'fetching',
-          error: null,
-        },
-        fetchKey
-      );
+      updateEntry({
+        fetchStatus: 'fetching',
+        error: null,
+      });
     }
 
     const promise = (async () => {
       try {
         const result = await runFetcher(
-          () => fetcher(controller.signal, rawKey.value),
+          () => fetcher(controller.signal, fetchRawKey),
           retry,
           retryDelay
         );
 
-        // Успех
         const prevEntry = queryClient.getEntry(fetchKey);
-        queryClient.setEntry(fetchKey, {
+
+        queryClient.setEntry(fetchRawKey, {
           ...prevEntry!,
           data: result,
           error: null,
@@ -217,14 +215,11 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
           console.debug(`Request aborted for key ${fetchKey}`);
           return;
         }
-        updateEntry(
-          {
-            status: 'error',
-            fetchStatus: 'idle',
-            error: err as TError,
-          },
-          fetchKey
-        );
+        updateEntry({
+          status: 'error',
+          fetchStatus: 'idle',
+          error: err as TError,
+        });
         onError?.(err);
         errorEvent.trigger(err as TError);
         queryClient.config.queries?.onError?.(err, fetchKey);
@@ -253,7 +248,7 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
   const setData = (
     updater: TData | ((prev?: Readonly<TData>) => TData | undefined)
   ) => {
-    const entry = queryClient.getEntry(rawKey.value);
+    const entry = queryClient.getEntry(key.value);
     const prevData = entry?.data as TData | undefined;
     const func =
       typeof updater === 'function'
@@ -288,7 +283,7 @@ export function useFetch<TData = unknown, TError = unknown, TSelected = TData>(
         lastSubscribedKey = newKey;
         const entry = queryClient.getEntry(newKey);
         if (!entry) {
-          queryClient.setEntry(newKey, {
+          queryClient.setEntry(rawKey.value, {
             data: initialData,
             error: null,
             status: initialData !== undefined ? 'success' : 'pending',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface UseQueryOptions<TData, TSelected = TData> {
 }
 
 export interface CacheEntry<TData = unknown> {
+  rawKey: string | readonly any[];
   data: TData | undefined;
   error: unknown | undefined;
   updatedAt: number;


### PR DESCRIPTION
## Description

Split cache operations into singular (exact match, O(1)) and plural (fuzzy match, O(N)) methods.

- Added `invalidateQueries`: invalidates all queries matching the filter.
- Added `updateEntries`: updates data for all queries matching the filter.
- Kept `invalidateQuery` and `updateEntry` for strict, performant single-key operations.
- Implemented `isMatch` logic for array prefix matching.

## Type of change
- [x] ✨ New feature (non-breaking change which adds functionality)

